### PR TITLE
feat(mlflow): allow specifying an existing secret name and key for db connection

### DIFF
--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mlflow/README.md
+++ b/charts/mlflow/README.md
@@ -1,6 +1,6 @@
 # mlflow
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.25.1](https://img.shields.io/badge/AppVersion-1.25.1-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.25.1](https://img.shields.io/badge/AppVersion-1.25.1-informational?style=flat-square)
 
 A Helm chart for MLflow (https://mlflow.org/)
 
@@ -32,6 +32,7 @@ A Helm chart for MLflow (https://mlflow.org/)
 | artifactStore.defaultArtifactRoot | string | `""` | Where to write/read artifacts, see the mlflow docs for options. Recommended to use S3 or S3 compatible blob storage. If left blank, artifacts are saved locally in the image and not persisted. |
 | artifactStore.s3EndpointUrl | string | `""` | If you use a non-AWS S3 host such as MinIO, specify the URI here |
 | backendStore.backendStoreUri | string | `"file:///opt/mlflow/mlruns"` | The [SQLAlchemy URI](https://docs.sqlalchemy.org/en/14/core/engines.html#database-urls) of the backend store to use (if sqlite is chosen, it is auto-created in the container and does not persist) |
+| backendStore.backendStoreUriExistingSecret | string | `nil` | Existing secret name and key to get the backendStoreUri from (name: foo, key: bar) |
 | extraEnv | object | `{}` | Extra environment variables to include in the mlflow pods, in the form of key: value pairs (for example, `FOO: bar`) |
 | extraEnvFrom | string | `nil` | Extra secrets or configmaps to get env-variables from |
 | fullnameOverride | string | `""` |  |

--- a/charts/mlflow/templates/deployment.yaml
+++ b/charts/mlflow/templates/deployment.yaml
@@ -47,8 +47,17 @@ spec:
                 name: {{ include "mlflow.fullname" . }}
           {{- if .Values.extraEnvFrom }}
             {{- .Values.extraEnvFrom | toYaml | nindent 12 }}
-          {{- end}}
+          {{- end }}
           env:
+          {{- if .Values.backendStore.backendStoreUriExistingSecret }}
+            {{- with .Values.backendStore.backendStoreUriExistingSecret }}
+            - name: MLFLOW_BACKEND_STORE_URI
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .name }}
+                  key: {{ .key }}
+            {{- end }}
+          {{- end }}
           {{- if (include "mlflow.s3.endpoint" .) }}
             - name: MLFLOW_S3_ENDPOINT_URL
               value: {{ include "mlflow.s3.endpoint" . }}

--- a/charts/mlflow/templates/secret.yaml
+++ b/charts/mlflow/templates/secret.yaml
@@ -1,3 +1,5 @@
+{{- $anySecrets := (or (not .Values.backendStore.backendStoreUriExistingSecret) .Values.minio.enabled) -}}
+{{- if $anySecrets -}}
 ---
 apiVersion: v1
 kind: Secret
@@ -5,8 +7,11 @@ metadata:
   name: {{ include "mlflow.fullname" . }}
 type: Opaque
 data:
+  {{- if .Values.backendStore.backendStoreUriExistingSecret | not }}
   MLFLOW_BACKEND_STORE_URI:  {{ include "mlflow.db.connection" . | trim | b64enc }}
+  {{- end }}
   {{- if .Values.minio.enabled }}
   AWS_ACCESS_KEY_ID: {{ .Values.minio.auth.rootUser | b64enc }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.minio.auth.rootPassword | b64enc }}
   {{- end }}
+{{- end -}}

--- a/charts/mlflow/values.yaml
+++ b/charts/mlflow/values.yaml
@@ -22,6 +22,8 @@ fullnameOverride: ""
 backendStore:
   # -- The [SQLAlchemy URI](https://docs.sqlalchemy.org/en/14/core/engines.html#database-urls) of the backend store to use (if sqlite is chosen, it is auto-created in the container and does not persist)
   backendStoreUri: file:///opt/mlflow/mlruns
+  # -- Existing secret name and key to get the backendStoreUri from (name: foo, key: bar)
+  backendStoreUriExistingSecret: ~
 
 artifactStore:
   # -- Where to write/read artifacts, see the mlflow docs for options. Recommended to use S3 or S3 compatible blob storage. If left blank, artifacts are saved locally in the image and not persisted.


### PR DESCRIPTION
This allows the user to specify an externally managed secret (and a key in that secret) to use for the sqlalchemy backend store uri. If specified, `backendStore.backendStoreUriExistingSecret` takes precedence over `backendStore.backendStoreUri`.