### PR TITLE
fix(mlflow): Fix configuration error when no secrets are deployed

### DIFF
--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -23,13 +23,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.25.1"
+appVersion: "1.26.0"
 
 # Chart dependencies MinIO and postgresql
 # Depending on your Kubernetes configuration, you probably don't want to enable these in production

--- a/charts/mlflow/README.md
+++ b/charts/mlflow/README.md
@@ -1,6 +1,6 @@
 # mlflow
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.25.1](https://img.shields.io/badge/AppVersion-1.25.1-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.26.0](https://img.shields.io/badge/AppVersion-1.26.0-informational?style=flat-square)
 
 A Helm chart for MLflow (https://mlflow.org/)
 

--- a/charts/mlflow/templates/_helpers.tpl
+++ b/charts/mlflow/templates/_helpers.tpl
@@ -94,3 +94,16 @@ The S3 bucket to use (if minio enabled, use that, otherwise use whatever specifi
 {{- default "" .Values.artifactStore.defaultArtifactRoot }}
 {{- end }}
 {{- end }}
+
+{{/*
+Logic to determine whether or not to deploy a secret
+(should be false if the secret is completely empty and user supplies all secrets manually)
+*/}}
+{{- define "mlflow.secret.deploy" -}}
+{{- $anySecrets := (or (not .Values.backendStore.backendStoreUriExistingSecret) .Values.minio.enabled) -}}
+{{- if $anySecrets -}}
+{{- print "true" -}}
+{{- else }}
+{{- print ""}}
+{{- end }}
+{{- end }}

--- a/charts/mlflow/templates/deployment.yaml
+++ b/charts/mlflow/templates/deployment.yaml
@@ -43,8 +43,10 @@ spec:
             - --expose-prometheus prometheus
           {{- end }}
           envFrom:
+          {{- if (include "mlflow.secret.deploy" .) }}
             - secretRef:
                 name: {{ include "mlflow.fullname" . }}
+          {{- end }}
           {{- if .Values.extraEnvFrom }}
             {{- .Values.extraEnvFrom | toYaml | nindent 12 }}
           {{- end }}

--- a/charts/mlflow/templates/secret.yaml
+++ b/charts/mlflow/templates/secret.yaml
@@ -1,5 +1,4 @@
-{{- $anySecrets := (or (not .Values.backendStore.backendStoreUriExistingSecret) .Values.minio.enabled) -}}
-{{- if $anySecrets -}}
+{{- if (include "mlflow.secret.deploy" .) -}}
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
There was an issue where the pod could not be scheduled
if there were no secrets (ie. if using an external secret for
the backend and not deploying minio).
This fixes that so that if no secrets are deployed through the chart,
no secret is referenced by deployment.yaml