### PR TITLE
fix(mlflow): add missing equals sign in prometheus argument

### DIFF
--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3
+version: 0.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mlflow/README.md
+++ b/charts/mlflow/README.md
@@ -1,6 +1,6 @@
 # mlflow
 
-![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.26.1](https://img.shields.io/badge/AppVersion-1.26.1-informational?style=flat-square)
+![Version: 0.4.4](https://img.shields.io/badge/Version-0.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.26.1](https://img.shields.io/badge/AppVersion-1.26.1-informational?style=flat-square)
 
 A Helm chart for MLflow (https://mlflow.org/)
 

--- a/charts/mlflow/templates/deployment.yaml
+++ b/charts/mlflow/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
             - --default-artifact-root={{ (include "mlflow.artifact.root" .) }}
           {{- end }}
           {{- if .Values.prometheus.expose }}
-            - --expose-prometheus prometheus
+            - --expose-prometheus=prometheus
           {{- end }}
           envFrom:
           {{- if (include "mlflow.secret.deploy" .) }}


### PR DESCRIPTION
Looks like the argument `--expose-prometheus prometheus` works locally but not in kubernetes. Changing to `--expose-prometheus=prometheus` works, of course.