### PR TITLE
feat(mlflow): add `podLabels` field

### DIFF
--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mlflow/README.md
+++ b/charts/mlflow/README.md
@@ -1,6 +1,6 @@
 # mlflow
 
-![Version: 0.4.4](https://img.shields.io/badge/Version-0.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.26.1](https://img.shields.io/badge/AppVersion-1.26.1-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.26.1](https://img.shields.io/badge/AppVersion-1.26.1-informational?style=flat-square)
 
 A Helm chart for MLflow (https://mlflow.org/)
 
@@ -53,6 +53,7 @@ A Helm chart for MLflow (https://mlflow.org/)
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | See [the Kubernetes docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) |
 | podAnnotations | object | `{}` | Extra annotations for all pods |
+| podLabels | object | `{}` | Extra labels to add to all resources |
 | podSecurityContext | object | `{}` | Security context for the pods. The default container can run as any user/group and does not run with elevated access |
 | postgresql.auth.database | string | `"mlflow"` |  |
 | postgresql.auth.password | string | `"mlflow"` |  |

--- a/charts/mlflow/templates/deployment.yaml
+++ b/charts/mlflow/templates/deployment.yaml
@@ -17,7 +17,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "mlflow.selectorLabels" . | nindent 8 }}
+        {{- include "mlflow.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/mlflow/templates/secret.yaml
+++ b/charts/mlflow/templates/secret.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "mlflow.fullname" . }}
+  labels:
+    {{- include "mlflow.labels" . | nindent 4 }}
 type: Opaque
 data:
   {{- if .Values.backendStore.backendStoreUriExistingSecret | not }}

--- a/charts/mlflow/templates/tests/test-mlflow-tracking.yaml
+++ b/charts/mlflow/templates/tests/test-mlflow-tracking.yaml
@@ -11,7 +11,7 @@ spec:
   securityContext:
     {{- toYaml .Values.podSecurityContext | nindent 4 }}
   containers:
-    - name: mlflow
+    - name: mlflow-tests
       image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
       command: ['python']
       securityContext:

--- a/charts/mlflow/values.yaml
+++ b/charts/mlflow/values.yaml
@@ -56,6 +56,9 @@ serviceAccount:
 # -- Extra annotations for all pods
 podAnnotations: {}
 
+# -- Extra labels to add to all resources
+podLabels: {}
+
 # -- Security context for the pods. The default container can run as any user/group and does not run with elevated access
 podSecurityContext: {}
 


### PR DESCRIPTION
allows the user to add extra labels to the mlflow pods

in my case i needed to add a pod label for cilium to open access to the pod for the prometheus scraper

Minor version bump to 0.5.0